### PR TITLE
Replace org-babel-get-header with org-babel--get-vars

### DIFF
--- a/ob-racket.el
+++ b/ob-racket.el
@@ -15,7 +15,7 @@ checking that a Racket listing has been typed in correctly.")
   (let ((pro (cdr (assoc :prologue params)))
 	(epi (cdr (assoc :epilogue params)))
 	(var-defs
-	 (let ((vars (mapcar #'cdr (org-babel-get-header params :var))))
+	 (let ((vars (mapcar #'cdr (org-babel--get-vars params))))
 	   (if (> (length vars) 0)
 	       (list
 		(concat


### PR DESCRIPTION
After org version 9.1 org-babel--get-vars should be used instead of
org-babel-get-header